### PR TITLE
Clean up document event listeners when component is unmounted.

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -96,6 +96,10 @@ var Slider = React.createClass({
     var addedState = this.addPositionsFromNumbers(stateObject, this.props.rightNumber);
     this.setState(addedState);
   },
+  componentWillUnmount: function() {
+    document.removeEventListener("mouseup", this.sliderUpdater);
+    document.removeEventListener("touchend", this.sliderUpdater);
+  },
   // a function of props and state
   moveConditionsMet: function(state) {
     var leftWithinBounds  = state.left >= 0 && state.left < this.props.width;


### PR DESCRIPTION
If you don't clean these up then React throws an invariant error when the component is unmounted and you click or touch anything. Bummer!
